### PR TITLE
Add verbose log for package queue

### DIFF
--- a/CookOnTheFlyServer.cpp
+++ b/CookOnTheFlyServer.cpp
@@ -3187,10 +3187,12 @@ void UCookOnTheFlyServer::QueueDiscoveredPackageOnDirector(UE::Cook::FPackageDat
 {
 	using namespace UE::Cook;
 
-	const FString FilePath = PackageData.GetFileName().ToString();
-	bool bIsWwiseFile = FilePath.Contains(TEXT("Wwise"), ESearchCase::IgnoreCase) ||
-						FilePath.EndsWith(TEXT(".bnk"), ESearchCase::IgnoreCase) ||
-						FilePath.EndsWith(TEXT(".wem"), ESearchCase::IgnoreCase);
+        const FString FilePath = PackageData.GetFileName().ToString();
+       UE_LOG(LogCook, Verbose, TEXT("QueueDiscoveredPackageOnDirector: %s, Instigator=%s"),
+               *PackageData.GetPackageName().ToString(), *Instigator.ToString());
+        bool bIsWwiseFile = FilePath.Contains(TEXT("Wwise"), ESearchCase::IgnoreCase) ||
+                                                FilePath.EndsWith(TEXT(".bnk"), ESearchCase::IgnoreCase) ||
+                                                FilePath.EndsWith(TEXT(".wem"), ESearchCase::IgnoreCase);
 	if (bIsWwiseFile)
 	{
 		AddWhitelistedPackage(PackageData.GetPackageName(), UE::Cook::FWorkerId::Local());


### PR DESCRIPTION
## Summary
- add a verbose log in `QueueDiscoveredPackageOnDirector`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686e2bc6ac18832ba2ede5682d825b7a