### PR TITLE
Handle Wwise packages in local worker requests

### DIFF
--- a/CookOnTheFlyServer.cpp
+++ b/CookOnTheFlyServer.cpp
@@ -6885,10 +6885,10 @@ void UCookOnTheFlyServer::Initialize( ECookMode::Type DesiredCookMode, ECookInit
 	AssetRegistry = IAssetRegistry::Get();
 	CachedDependencies = MakeUnique<UE::Cook::FCachedDependencies>();
 
-	if (!IsCookWorkerMode())
-	{
-		WorkerRequests.Reset(new UE::Cook::FWorkerRequestsLocal());
-	}
+       if (!IsCookWorkerMode())
+       {
+               WorkerRequests.Reset(new UE::Cook::FWorkerRequestsLocal(*this));
+       }
 	else
 	{
 		check(WorkerRequests); // Caller should have constructed

--- a/WorkerRequestsLocal.cpp
+++ b/WorkerRequestsLocal.cpp
@@ -17,6 +17,11 @@ namespace UE::Cook
 struct FInstigator;
 struct FPackageData;
 
+FWorkerRequestsLocal::FWorkerRequestsLocal(UCookOnTheFlyServer& InCOTFS)
+       : COTFS(&InCOTFS)
+{
+}
+
 bool FWorkerRequestsLocal::HasExternalRequests() const
 {
 	return ExternalRequests.HasRequests();
@@ -50,7 +55,19 @@ void FWorkerRequestsLocal::QueueDiscoveredPackage(UCookOnTheFlyServer& COTFS, FP
 
 void FWorkerRequestsLocal::AddStartCookByTheBookRequest(FFilePlatformRequest&& Request)
 {
-	ExternalRequests.EnqueueUnique(MoveTemp(Request));
+       FString FilePath = Request.GetFilename();
+       bool bIsWwiseFile = FilePath.Contains(TEXT("Wwise"), ESearchCase::IgnoreCase) ||
+               FilePath.EndsWith(TEXT(".bnk"), ESearchCase::IgnoreCase) ||
+               FilePath.EndsWith(TEXT(".wem"), ESearchCase::IgnoreCase);
+       if (bIsWwiseFile)
+       {
+               if (COTFS)
+               {
+                       COTFS->AddWhitelistedPackage(Request.GetFilename(), UE::Cook::FWorkerId::Local());
+               }
+               Request.SetWorkerAssignmentConstraint(UE::Cook::FWorkerId::Local());
+       }
+       ExternalRequests.EnqueueUnique(MoveTemp(Request));
 }
 
 void FWorkerRequestsLocal::InitializeCookOnTheFly()
@@ -137,5 +154,4 @@ void FWorkerRequestsLocal::LogAllRequestedFiles()
 {
 	ExternalRequests.LogAllRequestedFiles();
 }
-
-}
+}

--- a/WorkerRequestsLocal.h
+++ b/WorkerRequestsLocal.h
@@ -23,7 +23,8 @@ struct FPackageData;
 class FWorkerRequestsLocal : public IWorkerRequests
 {
 public:
-	virtual bool HasExternalRequests() const override;
+       explicit FWorkerRequestsLocal(UCookOnTheFlyServer& InCOTFS);
+       virtual bool HasExternalRequests() const override;
 	virtual int32 GetNumExternalRequests() const override;
 	virtual EExternalRequestType DequeueNextCluster(TArray<FSchedulerCallback>& OutCallbacks,
 		TArray<FFilePlatformRequest>& OutBuildRequests) override;
@@ -54,7 +55,7 @@ public:
 	virtual void LogAllRequestedFiles() override;
 
 private:
-	FExternalRequests ExternalRequests;
+       UCookOnTheFlyServer* COTFS = nullptr;
+       FExternalRequests ExternalRequests;
 };
-
-}
+}


### PR DESCRIPTION
## Summary
- allow `FWorkerRequestsLocal` to know its `UCookOnTheFlyServer`
- create the local worker request object with the current server
- lock Wwise assets scheduled through `AddStartCookByTheBookRequest` to the local worker

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686e86edffa8832bb28cf0d8f426499b